### PR TITLE
Fix BSD compile

### DIFF
--- a/src/Diagrams/Backend/CmdLine.hs
+++ b/src/Diagrams/Backend/CmdLine.hs
@@ -592,7 +592,7 @@ defaultLoopRender opts = when (opts ^. loop) $ do
       newProg     = newProgName (takeFileName srcPath) prog
       timeOfDay   = take 8 . drop 11 . show . eventTime
 
-  withManagerConf defaultConfig { confWatchMode = WatchModeOS } $
+  withManagerConf defaultConfig $
     \mgr -> do
       lock <- newIORef False
 


### PR DESCRIPTION
FSNotify alredy uses WatchModeOS for supported platforms. Current code fails to compile on BSD. This fixes the problem with no ill effects for other platforms.